### PR TITLE
Fatal error for datagrid totals when $skipAclWalkerCheck is true

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Extension/Totals/OrmTotalsExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Totals/OrmTotalsExtension.php
@@ -284,19 +284,21 @@ class OrmTotalsExtension extends AbstractExtension
             }
         };
 
-        $query = clone $this->masterQB;
-        $query
+        $queryBuilder = clone $this->masterQB;
+        $queryBuilder
             ->select($totalQueries)
             ->resetDQLPart('groupBy');
 
-        $parameters = $query->getParameters();
+        $parameters = $queryBuilder->getParameters();
         if ($parameters->count()) {
-            $query->resetDQLPart('where')
+            $queryBuilder->resetDQLPart('where')
                 ->resetDQLPart('having')
                 ->setParameters(new ArrayCollection());
         }
 
-        $this->addPageLimits($query, $pageData, $perPage);
+        $this->addPageLimits($queryBuilder, $pageData, $perPage);
+        
+        $query = $queryBuilder->getQuery();
 
         if (!$skipAclWalkerCheck) {
             $query = $this->aclHelper->apply($query);
@@ -322,8 +324,8 @@ class OrmTotalsExtension extends AbstractExtension
         $rootIdentifiers = $this->getRootIds($dataQueryBuilder);
 
         if (!$perPage) {
-            $query = clone $this->masterQB;
-            $data = $query
+            $queryBuilder = clone $this->masterQB;
+            $data = $queryBuilder
                 ->getQuery()
                 ->setFirstResult(null)
                 ->setMaxResults(null)


### PR DESCRIPTION
Due to introduction of the flag thr AclHelper::apply() method is not called in *all* cases. As this method internally converts QueryBuilder into Query, if it is not a Query already, the QueryBuilder does not get converted to a query if the flag is set. As there is no getScalarResult() method on QueryBuilder, this leads to a fatal error:

Fatal error: Call to undefined method Doctrine\ORM\QueryBuilder::getScalarResult() in /vagrant/vendor/oro/platform/src/Oro/Bundle/DataGridBundle/Extension/Totals/OrmTotalsExtension.php on line 308